### PR TITLE
Feature: alternate subcat support

### DIFF
--- a/qbreader/_api_utils.py
+++ b/qbreader/_api_utils.py
@@ -128,6 +128,16 @@ def category_correspondence(
         return (None, Subcategory.OTHER_FINE_ARTS)
 
     if typed_alt_subcat in [
+        AlternateSubcategory.ANTHROPOLOGY,
+        AlternateSubcategory.ECONOMICS,
+        AlternateSubcategory.LINGUISTICS,
+        AlternateSubcategory.PSYCHOLOGY,
+        AlternateSubcategory.SOCIOLOGY,
+        AlternateSubcategory.OTHER_SOCIAL_SCIENCE,
+    ]:
+        return (None, Subcategory.SOCIAL_SCIENCE)
+
+    if typed_alt_subcat in [
         AlternateSubcategory.DRAMA,
         AlternateSubcategory.LONG_FICTION,
         AlternateSubcategory.POETRY,

--- a/qbreader/_api_utils.py
+++ b/qbreader/_api_utils.py
@@ -93,6 +93,7 @@ def normalize_diff(unnormalized_diffs: UnnormalizedDifficulty):
     """Normalize a single or list of difficulty values to a comma separated string."""
     return normalize_enumlike(unnormalized_diffs, Difficulty)
 
+
 def normalize_cat(unnormalized_cats: UnnormalizedCategory):
     """Normalize a single or list of categories to a comma separated string."""
     return normalize_enumlike(unnormalized_cats, Category)

--- a/qbreader/asynchronous.py
+++ b/qbreader/asynchronous.py
@@ -185,7 +185,11 @@ class Async:
 
         url = BASE_URL + "/query"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "questionType": questionType,
@@ -272,7 +276,11 @@ class Async:
 
         url = BASE_URL + "/random-tossup"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
@@ -359,7 +367,11 @@ class Async:
 
         url = BASE_URL + "/random-bonus"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),

--- a/qbreader/asynchronous.py
+++ b/qbreader/asynchronous.py
@@ -185,6 +185,8 @@ class Async:
 
         url = BASE_URL + "/query"
 
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+
         data = {
             "questionType": questionType,
             "searchType": searchType,
@@ -196,9 +198,9 @@ class Async:
             "randomize": api_utils.normalize_bool(randomize),
             "setName": setName,
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
-            "alternateSubcategories": api_utils.normalize_alt_subcat(alternate_subcategories),
+            "categories": normalized_categories,
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "maxReturnLength": maxReturnLength,
             "tossupPagination": tossupPagination,
             "bonusPagination": bonusPagination,
@@ -270,11 +272,11 @@ class Async:
 
         url = BASE_URL + "/random-tossup"
 
-        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
+            "categories": normalized_categories,
             "subcategories": normalized_subcategories,
             "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
@@ -357,11 +359,11 @@ class Async:
 
         url = BASE_URL + "/random-bonus"
 
-        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
+            "categories": normalized_categories,
             "subcategories": normalized_subcategories,
             "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,

--- a/qbreader/asynchronous.py
+++ b/qbreader/asynchronous.py
@@ -19,6 +19,7 @@ from qbreader.types import (
     UnnormalizedCategory,
     UnnormalizedDifficulty,
     UnnormalizedSubcategory,
+    UnnormalizedAlternateSubcategory,
     Year,
 )
 
@@ -75,6 +76,7 @@ class Async:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         maxReturnLength: Optional[int] = 25,
         tossupPagination: Optional[int] = 1,
         bonusPagination: Optional[int] = 1,
@@ -114,6 +116,10 @@ class Async:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories : qbreader.types.UnnormalizedAlternateSubcategory, optional
+            The alternate subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enums or strings. The API does not check for
+            consistency between categories and subcategories
         maxReturnLength : int, default = 25
             The maximum number of questions to return.
         tossupPagination : int, default = 1
@@ -192,6 +198,7 @@ class Async:
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
             "subcategories": api_utils.normalize_subcat(subcategories),
+            "alternateSubcategories": api_utils.normalize_alt_subcat(alternate_subcategories),
             "maxReturnLength": maxReturnLength,
             "tossupPagination": tossupPagination,
             "bonusPagination": bonusPagination,
@@ -210,6 +217,7 @@ class Async:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         number: int = 1,
         min_year: int = Year.MIN_YEAR,
         max_year: int = Year.CURRENT_YEAR,
@@ -230,6 +238,10 @@ class Async:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories : qbreader.types.UnnormalizedAlternateSubcategory, optional
+            The alternate subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enums or strings. The API does not check for
+            consistency between categories and subcategories
         number : int, default = 1
             The number of tossups to return.
         min_year : int, default = Year.MIN_YEAR
@@ -258,13 +270,16 @@ class Async:
 
         url = BASE_URL + "/random-tossup"
 
+        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
-            "min_year": min_year,
-            "max_year": max_year,
+            "minYear": min_year,
+            "maxYear": max_year,
         }
         data = api_utils.prune_none(data)
 
@@ -280,6 +295,7 @@ class Async:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         number: int = 1,
         min_year: int = Year.MIN_YEAR,
         max_year: int = Year.CURRENT_YEAR,
@@ -301,6 +317,10 @@ class Async:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
+            The alternates subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enum variants or strings. The API does not check for consistency
+            between categories, subcategories, and alternate subcategories.
         number : int, default = 1
             The number of bonuses to return.
         min_year : int, default = Year.MIN_YEAR
@@ -337,13 +357,16 @@ class Async:
 
         url = BASE_URL + "/random-bonus"
 
+        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
-            "min_year": min_year,
-            "max_year": max_year,
+            "minYear": min_year,
+            "maxYear": max_year,
         }
         data = api_utils.prune_none(data)
 

--- a/qbreader/synchronous.py
+++ b/qbreader/synchronous.py
@@ -73,13 +73,13 @@ class Sync:
             The name of the set to search in.
         difficulties : qbreader.types.UnnormalizedDifficulty, optional
             The difficulties to search for. Can be a single or an array of `Difficulty`
-            enum variants, strings, or integers.
+            enums, strings, or integers.
         categories : qbreader.types.UnnormalizedCategory, optional
             The categories to search for. Can be a single or an array of `Category`
-            enum variants or strings.
+            enums or strings.
         subcategories : qbreader.types.UnnormalizedSubcategory, optional
             The subcategories to search for. Can be a single or an array of
-            `Subcategory` enum variants or strings. The API does not check for consistency
+            `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
         alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
             The alternates subcategories to search for. Can be a single or an array of
@@ -250,9 +250,7 @@ class Sync:
         }
         data = api_utils.prune_none(data)
 
-        print(data)
         response: requests.Response = requests.get(url, params=data)
-        print(response.url)
 
         if response.status_code != 200:
             raise Exception(str(response.status_code) + " bad request")

--- a/qbreader/synchronous.py
+++ b/qbreader/synchronous.py
@@ -150,7 +150,11 @@ class Sync:
 
         url = BASE_URL + "/query"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "questionType": questionType,
@@ -237,7 +241,11 @@ class Sync:
 
         url = BASE_URL + "/random-tossup"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
@@ -324,7 +332,11 @@ class Sync:
 
         url = BASE_URL + "/random-bonus"
 
-        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+        (
+            normalized_categories,
+            normalized_subcategories,
+            normalized_alternate_subcategories,
+        ) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),

--- a/qbreader/synchronous.py
+++ b/qbreader/synchronous.py
@@ -150,7 +150,7 @@ class Sync:
 
         url = BASE_URL + "/query"
 
-        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "questionType": questionType,
@@ -163,7 +163,7 @@ class Sync:
             "randomize": api_utils.normalize_bool(randomize),
             "setName": setName,
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
+            "categories": normalized_categories,
             "subcategories": normalized_subcategories,
             "alternateSubcategories": normalized_alternate_subcategories,
             "maxReturnLength": maxReturnLength,
@@ -237,11 +237,11 @@ class Sync:
 
         url = BASE_URL + "/random-tossup"
 
-        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
 
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
+            "categories": normalized_categories,
             "subcategories": normalized_subcategories,
             "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
@@ -324,10 +324,11 @@ class Sync:
 
         url = BASE_URL + "/random-bonus"
 
-        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+        (normalized_categories, normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_cats(categories, subcategories, alternate_subcategories)
+
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
-            "categories": api_utils.normalize_cat(categories),
+            "categories": normalized_categories,
             "subcategories": normalized_subcategories,
             "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,

--- a/qbreader/synchronous.py
+++ b/qbreader/synchronous.py
@@ -73,13 +73,13 @@ class Sync:
             The name of the set to search in.
         difficulties : qbreader.types.UnnormalizedDifficulty, optional
             The difficulties to search for. Can be a single or an array of `Difficulty`
-            enums, strings, or integers.
+            enum variants, strings, or integers.
         categories : qbreader.types.UnnormalizedCategory, optional
             The categories to search for. Can be a single or an array of `Category`
-            enums or strings.
+            enum variants or strings.
         subcategories : qbreader.types.UnnormalizedSubcategory, optional
             The subcategories to search for. Can be a single or an array of
-            `Subcategory` enums or strings. The API does not check for consistency
+            `Subcategory` enum variants or strings. The API does not check for consistency
             between categories and subcategories.
         alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
             The alternates subcategories to search for. Can be a single or an array of
@@ -150,6 +150,8 @@ class Sync:
 
         url = BASE_URL + "/query"
 
+        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+
         data = {
             "questionType": questionType,
             "searchType": searchType,
@@ -162,7 +164,8 @@ class Sync:
             "setName": setName,
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "maxReturnLength": maxReturnLength,
             "tossupPagination": tossupPagination,
             "bonusPagination": bonusPagination,
@@ -202,6 +205,10 @@ class Sync:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
+            The alternates subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enum variants or strings. The API does not check for consistency
+            between categories, subcategories, and alternate subcategories.
         number : int, default = 1
             The number of tossups to return.
         min_year : int, default = Year.MIN_YEAR
@@ -241,10 +248,11 @@ class Sync:
             "minYear": min_year,
             "maxYear": max_year,
         }
-
         data = api_utils.prune_none(data)
 
+        print(data)
         response: requests.Response = requests.get(url, params=data)
+        print(response.url)
 
         if response.status_code != 200:
             raise Exception(str(response.status_code) + " bad request")
@@ -256,6 +264,7 @@ class Sync:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         number: int = 1,
         min_year: int = Year.MIN_YEAR,
         max_year: int = Year.CURRENT_YEAR,
@@ -277,6 +286,10 @@ class Sync:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
+            The alternates subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enum variants or strings. The API does not check for consistency
+            between categories, subcategories, and alternate subcategories.
         number : int, default = 1
             The number of bonuses to return.
         min_year : int, default = Year.MIN_YEAR
@@ -313,13 +326,15 @@ class Sync:
 
         url = BASE_URL + "/random-bonus"
 
+        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
-            "min_year": min_year,
-            "max_year": max_year,
+            "minYear": min_year,
+            "maxYear": max_year,
         }
         data = api_utils.prune_none(data)
 

--- a/qbreader/synchronous.py
+++ b/qbreader/synchronous.py
@@ -16,9 +16,10 @@ from qbreader.types import (
     QuestionType,
     SearchType,
     Tossup,
-    UnnormalizedCategory,
     UnnormalizedDifficulty,
+    UnnormalizedCategory,
     UnnormalizedSubcategory,
+    UnnormalizedAlternateSubcategory,
     Year,
 )
 
@@ -40,6 +41,7 @@ class Sync:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         maxReturnLength: Optional[int] = 25,
         tossupPagination: Optional[int] = 1,
         bonusPagination: Optional[int] = 1,
@@ -79,6 +81,10 @@ class Sync:
             The subcategories to search for. Can be a single or an array of
             `Subcategory` enums or strings. The API does not check for consistency
             between categories and subcategories.
+        alternate_subcategories: qbreaader.types.UnnormalizedAlternateSubcategory, optional
+            The alternates subcategories to search for. Can be a single or an array of
+            `AlternateSubcategory` enum variants or strings. The API does not check for consistency
+            between categories, subcategories, and alternate subcategories.
         maxReturnLength : int, default = 25
             The maximum number of questions to return.
         tossupPagination : int, default = 1
@@ -175,6 +181,7 @@ class Sync:
         difficulties: UnnormalizedDifficulty = None,
         categories: UnnormalizedCategory = None,
         subcategories: UnnormalizedSubcategory = None,
+        alternate_subcategories: UnnormalizedAlternateSubcategory = None,
         number: int = 1,
         min_year: int = Year.MIN_YEAR,
         max_year: int = Year.CURRENT_YEAR,
@@ -223,14 +230,18 @@ class Sync:
 
         url = BASE_URL + "/random-tossup"
 
+        (normalized_subcategories, normalized_alternate_subcategories) = api_utils.normalize_subcats(subcategories, alternate_subcategories)
+
         data = {
             "difficulties": api_utils.normalize_diff(difficulties),
             "categories": api_utils.normalize_cat(categories),
-            "subcategories": api_utils.normalize_subcat(subcategories),
+            "subcategories": normalized_subcategories,
+            "alternateSubcategories": normalized_alternate_subcategories,
             "number": number,
-            "min_year": min_year,
-            "max_year": max_year,
+            "minYear": min_year,
+            "maxYear": max_year,
         }
+
         data = api_utils.prune_none(data)
 
         response: requests.Response = requests.get(url, params=data)

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -98,6 +98,9 @@ class AlternateSubcategory(enum.StrEnum):
     SOCIOLOGY = "Sociology"
     OTHER_SOCIAL_SCIENCE = "Other Social Science"
 
+    BELIEFS = "Beliefs"
+    PRACTICES = "Practices"
+
 class Difficulty(enum.StrEnum):
     """Question difficulty enum."""
 

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -270,10 +270,10 @@ class Tossup:
         difficulty: Difficulty,
         category: Category,
         subcategory: Subcategory,
-        alternate_subcategory: AlternateSubcategory,
         packet: PacketMetadata,
         set: SetMetadata,
         number: int,
+        alternate_subcategory: Optional[AlternateSubcategory] = None,
     ):
         self.question: str = question
         self.question_sanitized: str = question_sanitized
@@ -282,10 +282,10 @@ class Tossup:
         self.difficulty: Difficulty = difficulty
         self.category: Category = category
         self.subcategory: Subcategory = subcategory
-        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
         self.packet: PacketMetadata = packet
         self.set: SetMetadata = set
         self.number: int = number
+        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
 
     @classmethod
     def from_json(cls: Type[Self], json: dict[str, Any]) -> Self:
@@ -293,6 +293,7 @@ class Tossup:
 
         See https://www.qbreader.org/api-docs/schemas#tossups for schema.
         """
+        alternate_subcategory = json.get("alternate_subcategory", None)
         return cls(
             question=json["question"],
             question_sanitized=json["question_sanitized"],
@@ -301,10 +302,10 @@ class Tossup:
             difficulty=Difficulty(str(json["difficulty"])),
             category=Category(json["category"]),
             subcategory=Subcategory(json["subcategory"]),
-            alternate_subcategory=AlternateSubcategory(json["alternate_subcategory"]),
             packet=PacketMetadata.from_json(json["packet"]),
             set=SetMetadata.from_json(json["set"]),
             number=json["number"],
+            alternate_subcategory=AlternateSubcategory(alternate_subcategory) if alternate_subcategory else None,
         )
 
     def check_answer_sync(self, givenAnswer: str) -> AnswerJudgement:
@@ -357,10 +358,10 @@ class Bonus:
         difficulty: Difficulty,
         category: Category,
         subcategory: Subcategory,
-        alternate_subcategory: AlternateSubcategory,
         set: SetMetadata,
         packet: PacketMetadata,
         number: int,
+        alternate_subcategory: Optional[AlternateSubcategory] = None,
         values: Optional[Sequence[int]] = None,
         difficultyModifiers: Optional[Sequence[DifficultyModifier]] = None,
     ):
@@ -373,10 +374,10 @@ class Bonus:
         self.difficulty: Difficulty = difficulty
         self.category: Category = category
         self.subcategory: Subcategory = subcategory
-        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
         self.set: SetMetadata = set
         self.packet: PacketMetadata = packet
         self.number: int = number
+        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
         self.values: Optional[tuple[int, ...]] = tuple(values) if values else None
         self.difficultyModifiers: Optional[tuple[DifficultyModifier, ...]] = (
             tuple(difficultyModifiers) if difficultyModifiers else None
@@ -388,6 +389,7 @@ class Bonus:
 
         See https://www.qbreader.org/api-docs/schemas#bonus for schema.
         """
+        alternate_subcategory = json.get("alternate_subcategory", None)
         return cls(
             leadin=json["leadin"],
             leadin_sanitized=json["leadin_sanitized"],
@@ -398,10 +400,10 @@ class Bonus:
             difficulty=Difficulty(str(json["difficulty"])),
             category=Category(json["category"]),
             subcategory=Subcategory(json["subcategory"]),
-            alternate_subcategory=AlternateSubcategory(json["alternate_subcategory"]),
             set=SetMetadata.from_json(json["set"]),
             packet=PacketMetadata.from_json(json["packet"]),
             number=json["number"],
+            alternate_subcategory=AlternateSubcategory(alternate_subcategory) if alternate_subcategory else None,
             values=json.get("values", None),
             difficultyModifiers=json.get("difficultyModifiers", None),
         )

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -67,6 +67,38 @@ class Subcategory(enum.StrEnum):
     AUDITORY_FINE_ARTS = "Auditory Fine Arts"
     OTHER_FINE_ARTS = "Other Fine Arts"
 
+class AlternateSubcategory(enum.StrEnum):
+    """Question alternate subcategory enum."""
+
+    DRAMA = "Drama"
+    LONG_FICTION = "Long Fiction"
+    POETRY = "Poetry"
+    SHORT_FICTION = "Short Fiction"
+    MISC_LITERATURE = "Misc Literature"
+
+    MATH = "Math"
+    ASTRONOMY = "Astronomy"
+    COMPUTER_SCIENCE = "Computer Science"
+    EARTH_SCIENCE = "Earth Science"
+    ENGINEERING = "Engineering"
+    MISC_SCIENCE = "Misc Science"
+
+    ARCHITECTURE = "Architecture"
+    DANCE = "Dance"
+    FILM = "Film"
+    JAZZ = "Jazz"
+    OPERA = "Opera"
+    PHOTOGRAPHY = "Photography"
+    MISC_ARTS = "Misc Arts"
+
+    ANTHROPOLOGY = "Anthropology"
+    ECONOMICS = "Economics"
+    LINGUISTICS = "Linguistics"
+    PSYCHOLOGY = "Psychology"
+    SOCIOLOGY = "Sociology"
+    OTHER_SOCIAL_SCIENCE = "Other Social Science"
+
+    NONE = "None"
 
 class Difficulty(enum.StrEnum):
     """Question difficulty enum."""
@@ -240,6 +272,7 @@ class Tossup:
         difficulty: Difficulty,
         category: Category,
         subcategory: Subcategory,
+        alternate_subcategory: AlternateSubcategory,
         packet: PacketMetadata,
         set: SetMetadata,
         number: int,
@@ -251,6 +284,7 @@ class Tossup:
         self.difficulty: Difficulty = difficulty
         self.category: Category = category
         self.subcategory: Subcategory = subcategory
+        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
         self.packet: PacketMetadata = packet
         self.set: SetMetadata = set
         self.number: int = number
@@ -269,6 +303,7 @@ class Tossup:
             difficulty=Difficulty(str(json["difficulty"])),
             category=Category(json["category"]),
             subcategory=Subcategory(json["subcategory"]),
+            alternate_subcategory=AlternateSubcategory(json.get("alternate_subcategory", "None")),
             packet=PacketMetadata.from_json(json["packet"]),
             set=SetMetadata.from_json(json["set"]),
             number=json["number"],
@@ -299,6 +334,7 @@ class Tossup:
             and self.difficulty == other.difficulty
             and self.category == other.category
             and self.subcategory == other.subcategory
+            and self.alternate_subcategory == other.alternate_subcategory
             and self.packet == other.packet
             and self.set == other.set
             and self.number == other.number
@@ -323,6 +359,7 @@ class Bonus:
         difficulty: Difficulty,
         category: Category,
         subcategory: Subcategory,
+        alternate_subcategory: AlternateSubcategory,
         set: SetMetadata,
         packet: PacketMetadata,
         number: int,
@@ -338,6 +375,7 @@ class Bonus:
         self.difficulty: Difficulty = difficulty
         self.category: Category = category
         self.subcategory: Subcategory = subcategory
+        self.alternate_subcategory: AlternateSubcategory = alternate_subcategory
         self.set: SetMetadata = set
         self.packet: PacketMetadata = packet
         self.number: int = number
@@ -362,6 +400,7 @@ class Bonus:
             difficulty=Difficulty(str(json["difficulty"])),
             category=Category(json["category"]),
             subcategory=Subcategory(json["subcategory"]),
+            alternate_subcategory=AlternateSubcategory(json["alternate_subcategory"]),
             set=SetMetadata.from_json(json["set"]),
             packet=PacketMetadata.from_json(json["packet"]),
             number=json["number"],
@@ -396,6 +435,7 @@ class Bonus:
             and self.difficulty == other.difficulty
             and self.category == other.category
             and self.subcategory == other.subcategory
+            and self.alternate_subcategory == other.alternate_subcategory
             and self.set == other.set
             and self.packet == other.packet
             and self.number == other.number
@@ -635,6 +675,12 @@ UnnormalizedSubcategory: TypeAlias = Optional[
 """Type alias for unnormalized subcategories. Union of `Subcategory`, `str`, and
 `collections.abc.Iterable` containing either."""
 
+UnnormalizedAlternateSubcategory: TypeAlias = Optional[
+    Union[AlternateSubcategory, str, Iterable[Union[AlternateSubcategory, str]]]
+]
+"""Type alias for unnormalized alternate subcategories. Union of `AlternateSubcategory`, `str`, and
+`collections.abc.Iterable` containing either."""
+
 
 __all__ = (
     "Tossup",
@@ -644,6 +690,7 @@ __all__ = (
     "AnswerJudgement",
     "Category",
     "Subcategory",
+    "AlternateSubcategory",
     "Difficulty",
     "Directive",
     "QuestionType",
@@ -652,4 +699,5 @@ __all__ = (
     "UnnormalizedDifficulty",
     "UnnormalizedCategory",
     "UnnormalizedSubcategory",
+    "UnnormalizedAlternateSubcategory"
 )

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -303,7 +303,7 @@ class Tossup:
             difficulty=Difficulty(str(json["difficulty"])),
             category=Category(json["category"]),
             subcategory=Subcategory(json["subcategory"]),
-            alternate_subcategory=AlternateSubcategory(json.get("alternate_subcategory", "None")),
+            alternate_subcategory=AlternateSubcategory(json["alternate_subcategory"]),
             packet=PacketMetadata.from_json(json["packet"]),
             set=SetMetadata.from_json(json["set"]),
             number=json["number"],

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -98,8 +98,6 @@ class AlternateSubcategory(enum.StrEnum):
     SOCIOLOGY = "Sociology"
     OTHER_SOCIAL_SCIENCE = "Other Social Science"
 
-    NONE = "None"
-
 class Difficulty(enum.StrEnum):
     """Question difficulty enum."""
 

--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -67,6 +67,7 @@ class Subcategory(enum.StrEnum):
     AUDITORY_FINE_ARTS = "Auditory Fine Arts"
     OTHER_FINE_ARTS = "Other Fine Arts"
 
+
 class AlternateSubcategory(enum.StrEnum):
     """Question alternate subcategory enum."""
 
@@ -100,6 +101,7 @@ class AlternateSubcategory(enum.StrEnum):
 
     BELIEFS = "Beliefs"
     PRACTICES = "Practices"
+
 
 class Difficulty(enum.StrEnum):
     """Question difficulty enum."""
@@ -308,7 +310,9 @@ class Tossup:
             packet=PacketMetadata.from_json(json["packet"]),
             set=SetMetadata.from_json(json["set"]),
             number=json["number"],
-            alternate_subcategory=AlternateSubcategory(alternate_subcategory) if alternate_subcategory else None,
+            alternate_subcategory=AlternateSubcategory(alternate_subcategory)
+            if alternate_subcategory
+            else None,
         )
 
     def check_answer_sync(self, givenAnswer: str) -> AnswerJudgement:
@@ -406,7 +410,9 @@ class Bonus:
             set=SetMetadata.from_json(json["set"]),
             packet=PacketMetadata.from_json(json["packet"]),
             number=json["number"],
-            alternate_subcategory=AlternateSubcategory(alternate_subcategory) if alternate_subcategory else None,
+            alternate_subcategory=AlternateSubcategory(alternate_subcategory)
+            if alternate_subcategory
+            else None,
             values=json.get("values", None),
             difficultyModifiers=json.get("difficultyModifiers", None),
         )
@@ -702,5 +708,5 @@ __all__ = (
     "UnnormalizedDifficulty",
     "UnnormalizedCategory",
     "UnnormalizedSubcategory",
-    "UnnormalizedAlternateSubcategory"
+    "UnnormalizedAlternateSubcategory",
 )


### PR DESCRIPTION
See #8 

This should work now, for both tossups & bonuses on both `Sync` and `Async` clients.

Example:
```py
c = Sync()

print(c.random_tossup(alternate_subcategories=["Poetry"])[0])
```
This will send a GET request to the QB Reader API endpoint, automatically adding `subcategories=Other%20Literature` on to the querystring.

And for the async example:
```py
a = Async()

async def t():
    a = await Async.create()

    print(
        (await a.random_tossup(alternate_subcategories=["Math"]))[0]
    )

    print(
        (await a.random_bonus(alternate_subcategories=["Computer Science"]))[0]
    )
    
    await a.close()

print(asyncio.run(t()))
```
