### PR TITLE
Full test coverage of `qbreader` folder

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -180,13 +180,13 @@ class TestAsync:
             ),
             (
                 {
-                    "min_year":"not an int",
+                    "min_year": "not an int",
                 },
                 TypeError,
             ),
             (
                 {
-                    "max_year":"not an int",
+                    "max_year": "not an int",
                 },
                 TypeError,
             ),

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -178,6 +178,18 @@ class TestAsync:
                 },
                 ValueError,
             ),
+            (
+                {
+                    "min_year":"not an int",
+                },
+                TypeError,
+            ),
+            (
+                {
+                    "max_year":"not an int",
+                },
+                TypeError,
+            ),
         ],
     )
     async def test_query_exception(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,71 @@ class TestNormalization:
     """Test normalization functions."""
 
     @pytest.mark.parametrize(
+        "unnormalized, enum_type, expected",
+        [
+            (None, Category, ""),
+            (Difficulty.OPEN, Difficulty, "10"),
+            ("Long Fiction", AlternateSubcategory, "Long Fiction"),
+            ("0", Difficulty, "0"),
+            (1, Difficulty, "1"),
+            ([Category.FINE_ARTS, Category.RELIGION], Category, "Religion,Fine Arts"),
+            (
+                ["Religion", "Pop Culture", "Mythology"],
+                Category,
+                "Mythology,Pop Culture,Religion",
+            ),
+            (["0", "1", "2"], Difficulty, "2,1,0"),
+            ([0, 1, 2], Difficulty, "1,2,0"),
+            (["History", "History"], Category, "History"),
+            ("Science", Subcategory, "Science"),
+        ],
+    )
+    def test_normalize_enumlike(self, unnormalized, enum_type, expected):
+        result = api_utils.normalize_enumlike(unnormalized, enum_type)
+        sorted_result = sorted(result.split(","))
+        sorted_expected = sorted(expected.split(","))
+        assert sorted_result == sorted_expected
+
+    @pytest.mark.parametrize(
+        "unnormalized, enum_type, exception",
+        [
+            (True, Category, TypeError),
+            (3.5, Category, TypeError),
+            (["Social Science", 3.5], Category, TypeError),
+        ],
+    )
+    def test_normalize_enumlike_exception(self, unnormalized, enum_type, exception):
+        assert_exception(
+            api_utils.normalize_enumlike, exception, unnormalized, enum_type
+        )
+
+    @pytest.mark.parametrize(
+        "unnormalized, enum_type, expected, warning",
+        [
+            (11, Difficulty, "", UserWarning),
+            ("0.5", Difficulty, "", UserWarning),
+            ("History", AlternateSubcategory, "", UserWarning),
+            (AlternateSubcategory.JAZZ, Category, "", UserWarning),
+            (
+                [Category.SCIENCE, Category.FINE_ARTS, Subcategory.MUSIC],
+                Category,
+                "Science,Fine Arts",
+                UserWarning,
+            ),
+            ([Difficulty.OPEN, 999], Difficulty, "10", UserWarning),
+        ],
+    )
+    def test_normalize_enumlike_warning(
+        self, unnormalized, enum_type, expected, warning
+    ):
+        result = assert_warning(
+            api_utils.normalize_enumlike, warning, unnormalized, enum_type
+        )
+        sorted_result = sorted(result.split(","))
+        sorted_expected = sorted(expected.split(","))
+        assert sorted_result == sorted_expected
+
+    @pytest.mark.parametrize(
         "boolean, expected",
         [
             (True, "true"),
@@ -188,18 +253,30 @@ class TestNormalization:
             (["History", "Literature"], None, None, ("History,Literature", "", "")),
             (None, "Other Science", None, ("", "Other Science", "")),
             (None, ["Other Science", "Sports"], None, ("", "Other Science,Sports", "")),
-            (None, None, ["Astronomy", "Earth Science"], ("", "Other Science", "Astronomy,Earth Science")),
             (
-                    ["Social Science"],
-                    ["Television"],
-                    ["Beliefs", "Drama", "Misc Science"],
-                    ("Social Science,Literature", "Television,Other Science", "Beliefs,Drama,Misc Science"),
+                None,
+                None,
+                ["Astronomy", "Earth Science"],
+                ("", "Other Science", "Astronomy,Earth Science"),
             ),
-            (["History", "History", "History", "History", "History"], [], [], ("History", "", "")),
+            (
+                ["Social Science"],
+                ["Television"],
+                ["Beliefs", "Drama", "Misc Science"],
+                (
+                    "Social Science,Literature",
+                    "Television,Other Science",
+                    "Beliefs,Drama,Misc Science",
+                ),
+            ),
+            (["History", "History", "History", "History"], [], [], ("History", "", "")),
         ],
     )
     def test_normalize_cats(self, cats, subcats, alt_subcats, expected):
-        assert [sorted(tuple(x)) for x in api_utils.normalize_cats(cats, subcats, alt_subcats)] == [sorted(tuple(x)) for x in expected]
+        result = api_utils.normalize_cats(cats, subcats, alt_subcats)
+        sorted_result = [sorted(x.split(",")) for x in result]
+        sorted_expected = [sorted(x.split(",")) for x in expected]
+        assert sorted_result == sorted_expected
 
     @pytest.mark.parametrize(
         "cats, subcats, alt_subcats, exception",
@@ -208,10 +285,13 @@ class TestNormalization:
             ("Science ", None, [], ValueError),
             ("Geography", [None], [], ValueError),
             (["History", ""], [], [], ValueError),
-        ]
+        ],
     )
     def test_normalize_cats_exception(self, cats, subcats, alt_subcats, exception):
-        assert_exception(api_utils.normalize_cats, exception, cats, subcats, alt_subcats)
+        assert_exception(
+            api_utils.normalize_cats, exception, cats, subcats, alt_subcats
+        )
+
 
 class TestMiscUtil:
     """Test miscellaneous util functions"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,11 +180,38 @@ class TestNormalization:
         "cats, subcats, alt_subcats, expected",
         [
             (None, None, None, ("", "", "")),
-            (["Literature", "History"], ["American History"], ["Drama"], ("Literature,History", "American History", "Drama")),
+            ([], [], [], ("", "", "")),
+            (None, None, "Beliefs", ("", "", "Beliefs")),
+            (None, None, "Drama", ("Literature", "", "Drama")),
+            (None, None, "Jazz", ("", "Other Fine Arts", "Jazz")),
+            ("History", None, None, ("History", "", "")),
+            (["History", "Literature"], None, None, ("History,Literature", "", "")),
+            (None, "Other Science", None, ("", "Other Science", "")),
+            (None, ["Other Science", "Sports"], None, ("", "Other Science,Sports", "")),
+            (None, None, ["Astronomy", "Earth Science"], ("", "Other Science", "Astronomy,Earth Science")),
+            (
+                    ["Social Science"],
+                    ["Television"],
+                    ["Beliefs", "Drama", "Misc Science"],
+                    ("Social Science,Literature", "Television,Other Science", "Beliefs,Drama,Misc Science"),
+            ),
+            (["History", "History", "History", "History", "History"], [], [], ("History", "", "")),
         ],
     )
     def test_normalize_cats(self, cats, subcats, alt_subcats, expected):
         assert [sorted(tuple(x)) for x in api_utils.normalize_cats(cats, subcats, alt_subcats)] == [sorted(tuple(x)) for x in expected]
+
+    @pytest.mark.parametrize(
+        "cats, subcats, alt_subcats, exception",
+        [
+            (None, None, "", ValueError),
+            ("Science ", None, [], ValueError),
+            ("Geography", [None], [], ValueError),
+            (["History", ""], [], [], ValueError),
+        ]
+    )
+    def test_normalize_cats_exception(self, cats, subcats, alt_subcats, exception):
+        assert_exception(api_utils.normalize_cats, exception, cats, subcats, alt_subcats)
 
 class TestMiscUtil:
     """Test miscellaneous util functions"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 import qbreader._api_utils as api_utils
-from qbreader.types import Category, Difficulty, Subcategory
+from qbreader.types import Category, Difficulty, Subcategory, AlternateSubcategory
 from tests import assert_exception, assert_warning
 
 
@@ -176,8 +176,11 @@ class TestNormalization:
     def test_normalize_subcat_warning(self, subcat, warning):
         assert assert_warning(api_utils.normalize_cat, warning, subcat) == ""
 
+class TestMiscUtil:
+    """Test util functions that don't fall under normalization"""
+
     @pytest.mark.parametrize(
-        "dict, expected",
+        "dictionary, expected",
         [
             ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3}),
             ({"a": 1, "b": None, "c": 3}, {"a": 1, "c": 3}),
@@ -188,5 +191,24 @@ class TestNormalization:
             ),
         ],
     )
-    def test_prune_none(self, dict, expected):
-        assert api_utils.prune_none(dict) == expected
+    def test_prune_none(self, dictionary, expected):
+        assert api_utils.prune_none(dictionary) == expected
+
+    @pytest.mark.parametrize(
+        "typed_alt_subcat, expected",
+        [
+            (AlternateSubcategory.ASTRONOMY, (None, Subcategory.OTHER_SCIENCE)),
+            (AlternateSubcategory.ARCHITECTURE, (None, Subcategory.OTHER_FINE_ARTS)),
+            (AlternateSubcategory.ANTHROPOLOGY, (None, Subcategory.SOCIAL_SCIENCE)),
+            (AlternateSubcategory.DRAMA, (Category.LITERATURE, None)),
+            (AlternateSubcategory.BELIEFS, (None, None)),
+            (AlternateSubcategory.PRACTICES, (None, None)),
+            (AlternateSubcategory.MISC_ARTS, (None, Subcategory.OTHER_FINE_ARTS)),
+            (AlternateSubcategory.MISC_LITERATURE, (Category.LITERATURE, None)),
+            (AlternateSubcategory.MISC_SCIENCE, (None, Subcategory.OTHER_SCIENCE)),
+            (AlternateSubcategory.OTHER_SOCIAL_SCIENCE, (None, Subcategory.SOCIAL_SCIENCE))
+        ]
+    )
+    def test_category_correspondence(self, typed_alt_subcat, expected):
+        assert api_utils.category_correspondence(typed_alt_subcat) == expected
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 import qbreader._api_utils as api_utils
-from qbreader.types import Category, Difficulty, Subcategory, AlternateSubcategory
+from qbreader.types import AlternateSubcategory, Category, Difficulty, Subcategory
 from tests import assert_exception, assert_warning
 
 
@@ -176,8 +176,18 @@ class TestNormalization:
     def test_normalize_subcat_warning(self, subcat, warning):
         assert assert_warning(api_utils.normalize_cat, warning, subcat) == ""
 
+    @pytest.mark.parametrize(
+        "cats, subcats, alt_subcats, expected",
+        [
+            (None, None, None, ("", "", "")),
+            (["Literature", "History"], ["American History"], ["Drama"], ("Literature,History", "American History", "Drama")),
+        ],
+    )
+    def test_normalize_cats(self, cats, subcats, alt_subcats, expected):
+        assert [sorted(tuple(x)) for x in api_utils.normalize_cats(cats, subcats, alt_subcats)] == [sorted(tuple(x)) for x in expected]
+
 class TestMiscUtil:
-    """Test util functions that don't fall under normalization"""
+    """Test miscellaneous util functions"""
 
     @pytest.mark.parametrize(
         "dictionary, expected",
@@ -206,9 +216,20 @@ class TestMiscUtil:
             (AlternateSubcategory.MISC_ARTS, (None, Subcategory.OTHER_FINE_ARTS)),
             (AlternateSubcategory.MISC_LITERATURE, (Category.LITERATURE, None)),
             (AlternateSubcategory.MISC_SCIENCE, (None, Subcategory.OTHER_SCIENCE)),
-            (AlternateSubcategory.OTHER_SOCIAL_SCIENCE, (None, Subcategory.SOCIAL_SCIENCE))
-        ]
+        ],
     )
     def test_category_correspondence(self, typed_alt_subcat, expected):
         assert api_utils.category_correspondence(typed_alt_subcat) == expected
 
+    @pytest.mark.parametrize(
+        "typed_alt_subcat, exception",
+        [
+            ("hey this isn't an alternate subca", ValueError),
+            (15, ValueError),
+            ([AlternateSubcategory.ASTRONOMY], ValueError),
+            ({AlternateSubcategory.MATH, AlternateSubcategory.FILM}, ValueError),
+            ((AlternateSubcategory.DRAMA, AlternateSubcategory.JAZZ), ValueError),
+        ],
+    )
+    def test_category_correspondence_exception(self, typed_alt_subcat, exception):
+        assert_exception(api_utils.category_correspondence, exception, typed_alt_subcat)


### PR DESCRIPTION
This pull request closes #16 and:
* Adds success and exception tests for `normalize_cats` and `category_correspondence` as detailed in #16
* Adds success, exception, and warning tests for `normalize_enumlike` which at the moment is only implicitly covered by other tests
* Adds test to `test_query_min_max_year_range` in `test_async` which existed in `test_sync` but wasn't added to the asynchronous version

This should mean 100% coverage of the `qbreader` folder.