### PR TITLE
Update min and max year

### DIFF
--- a/qbreader/types.py
+++ b/qbreader/types.py
@@ -146,8 +146,8 @@ class Directive(enum.StrEnum):
 class Year(enum.IntEnum):
     """Min/max year enum."""
 
-    MIN_YEAR = 2010
-    CURRENT_YEAR = 2024
+    MIN_YEAR = 2000
+    CURRENT_YEAR = 2026
 
 
 class AnswerJudgement:


### PR DESCRIPTION
The oldest questions in the database seem to come from the 2000 PACE NSC, and the newest obviously from 2026 (if I'm not mistaken, ACF Nationals). This pull request updates the year enum in `types` to reflect this.